### PR TITLE
fix(lib): let Renovate manage the rust base image ARG

### DIFF
--- a/lib/Dockerfile
+++ b/lib/Dockerfile
@@ -1,8 +1,11 @@
 # ── Stage 1: build ─────────────────────────────────────────────────────────
 ARG PG_VERSION=18
-ARG RUST_VERSION=1.94
+# Full image tag (not just the version) so Renovate can manage the ARG default
+# directly. A partial variable like rust:${RUST_VERSION}-slim-bookworm breaks
+# Renovate's auto-replace ("Cannot find replaceString in current file content").
+ARG RUST_VERSION=1.96-slim-bookworm
 
-FROM rust:${RUST_VERSION}-slim-bookworm AS builder
+FROM rust:${RUST_VERSION} AS builder
 
 # Re-declare ARGs after FROM so they are available within this build stage
 ARG PG_VERSION=18


### PR DESCRIPTION
## Problem

Renovate fails to apply `rust` updates to `lib/Dockerfile` on every run:

```
Cannot find replaceString in current file content. Was it already updated?
replaceString: rust:1.94-slim-bookworm
```

The `FROM` line used a **partial variable** in the tag:

```dockerfile
ARG RUST_VERSION=1.94
FROM rust:${RUST_VERSION}-slim-bookworm AS builder
```

Renovate substitutes the ARG to resolve the dependency for the registry lookup, but because the variable is only *part* of the tag, its computed `replaceString` is the resolved `rust:1.94-slim-bookworm` -- which never appears verbatim in the file. Auto-replace can't find it and silently fails.

This already caused drift: PR #10 bumped the workflow toolchain `1.94 -> 1.96`, but the matching Dockerfile change dropped, leaving the image stuck on `1.94`.

## Fix

Move the full image tag into the ARG default (Renovate's canonical ARG pattern). The variable then constitutes the entire tag, so Renovate maps the dependency back to the ARG line and uses its value as the `replaceString`. Docker versioning keeps the `-slim-bookworm` suffix on future bumps.

```dockerfile
ARG RUST_VERSION=1.96-slim-bookworm
FROM rust:${RUST_VERSION} AS builder
```

Also resolves the existing drift to `1.96`, matching the toolchain the `test` job validates against.

## Notes

- `RUST_VERSION` is referenced only in `lib/Dockerfile` (not passed as a build-arg from either `docker-bake.hcl`), so changing the default value is safe.
- The `repository-changed` abort seen alongside this in the logs is an unrelated transient (a commit landed on `main` mid-run) and needs no change.